### PR TITLE
Update scraper schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project has two parts:
 
 - While the project is defined to be as generalized as possible, the current functionalities have been tested on Finland job market.
 
-- LinkedIn has set a limit on the publicly available jobs number, and only allows scraping the first 1000 jobs.
+- LinkedIn enforces a 1000-result limit per search query. For comprehensive data collection, use overlapping time windows to ensure complete coverage.
 
 ## References
 

--- a/configs/scrapy_config.json
+++ b/configs/scrapy_config.json
@@ -196,9 +196,10 @@
     ],
     "periods":
     {
-        "daily": "r86400",
-        "weekly": "r604800",
-        "monthly": "r2592000",
+        "past_2_hours": "r7200",
+        "past_24_hours": "r86400",
+        "past_week": "r604800",
+        "past_month": "r2592000",
         "any_time": ""
     },
     "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"

--- a/src/linkedin_job_search/README.md
+++ b/src/linkedin_job_search/README.md
@@ -1,6 +1,6 @@
 # LinkedIn Job Search
 
-Scrapes the linkedin job posts on a country level.
+Scrapes the linkedin job posts based on a given country.
 
 ## Introduction
 
@@ -30,15 +30,18 @@ The process can be done by calling the scraper to crawl the data with the follow
 Two arguments should be given to the scraper:
 - country: the name of the country. If it has more than one word, just replace the `space` with `_`. e.g. `New_Zealand`.
 - period: the basis for the scraper to look for. options are:
-  - `daily`
-  - `weekly`
-  -  `monthly`
+  - `past_two_hours`
+  - `past_24_hours`
+  - `past_week`
+  - `past_month`
   - `any_time`
 
 ```bash
 cd src/linkedin_job_search
-scrapy crawl job_scraper -a country=finland -a period=daily
+scrapy crawl job_scraper -a country=finland -a period=past_two_hours
 ```
+
+Note: LinkedIn has a 1000-result limit per search query. For larger datasets, use overlapping time windows to ensure complete coverage.
 
 Running the scraper periodically can be done with `crontab` job with the `run_scrapy.sh` helper script.
 
@@ -48,5 +51,5 @@ crontab -e
 ```
 Then, add the job and modify the command:
 ```bash
-00 24 * * * /bin/bash /path/to/run_scrapy.sh >> /path/to/logs.log 2>&1
+0 */2 * * * /bin/bash /path/to/run_scrapy.sh >> /path/to/logs.log 2>&1
 ```

--- a/src/linkedin_job_search/run_scrapy.sh
+++ b/src/linkedin_job_search/run_scrapy.sh
@@ -7,7 +7,7 @@ source /path/to/conda/activate/script lja
 cd /path/to/Linkedin_job_analysis/src/linkedin_job_search
 
 # Run the Scrapy spider
-scrapy crawl job_scraper -a country=finland -a period=daily
+scrapy crawl job_scraper -a country=finland -a period=past_2_hours
 
 # Deactivate the conda environment
 conda deactivate


### PR DESCRIPTION
This PR contains a suggestion fix to overcome the LinkedIn limit that enforces only 1000 result per query. The solution was to use an overlapping time window (2 hours) instead of the daily basis window. 

This update also include implementing a logic for de-duplication in the database.